### PR TITLE
Fixed GUI_COMMAND to be POSIX compliant

### DIFF
--- a/quicktracer/quicktracer_lib.py
+++ b/quicktracer/quicktracer_lib.py
@@ -19,7 +19,7 @@ CUSTOM_DISPLAY = 'custom_display'
 VIEW = 'view'
 VIEW_BOX = 'view_box'
 
-GUI_COMMAND = 'python gui_pyqtgraph.py'
+GUI_COMMAND = ['python', 'gui_pyqtgraph.py']
 child_process = None
 have_notified_about_child_dying = False
 


### PR DESCRIPTION
On Mac Catalina 10.15.7 with pipenv 2020.11.15 and Python 3.9.2 it wasn't possible to run.
Now it is.